### PR TITLE
Add Merge PDF workflow step

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# SpringPdfCreator
+
+This project provides endpoints for PDF manipulation using Spring Boot and iText.
+
+## Merge PDF Endpoint
+
+`POST /pdf/mergepdf`
+
+Accepts JSON body:
+
+```json
+{
+  "urls": ["http://example.com/file1.pdf", "http://example.com/file2.pdf"]
+}
+```
+
+Returns the merged PDF created via `MergeStep` workflow.

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ apply plugin: "com.github.jk1.dependency-license-report"
 apply plugin: 'org.owasp.dependencycheck'
 
 bootJar {
-    baseName = 'SpringPdfCreator'
-    version = '0.1.0'
+    archiveBaseName = 'SpringPdfCreator'
+    archiveVersion = '0.1.0'
 }
 
 repositories {

--- a/src/main/java/com/fyhao/springwebapps/PdfController.java
+++ b/src/main/java/com/fyhao/springwebapps/PdfController.java
@@ -21,6 +21,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.fyhao.springwebapps.business.ExtractImageService;
 import com.fyhao.springwebapps.business.PasswordprotectService;
 import com.fyhao.springwebapps.dto.ExtractImageRequest;
+import com.fyhao.springwebapps.dto.MergePdfRequest;
 import com.fyhao.springwebapps.dto.PasswordprotectRequest;
 import com.fyhao.springwebapps.wf.WFRequest;
 import com.fyhao.springwebapps.wf.WorkflowExecutor;
@@ -99,9 +100,27 @@ public class PdfController {
 	}
     //uploadpdfextractimage
     @RequestMapping(value="/uploadpdfpasswordprotect", method = RequestMethod.POST, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	public void uploadpdfpasswordprotect(@RequestParam MultipartFile file, @RequestParam String pwd, HttpServletResponse response) throws Exception {
-    	response.setContentType("application/pdf");
-    	passwordprotectService.uploadpdfpasswordprotect(file, pwd, response.getOutputStream());
-	}
+        public void uploadpdfpasswordprotect(@RequestParam MultipartFile file, @RequestParam String pwd, HttpServletResponse response) throws Exception {
+        response.setContentType("application/pdf");
+        passwordprotectService.uploadpdfpasswordprotect(file, pwd, response.getOutputStream());
+        }
+
+    /**
+     * Merge multiple PDF URLs into a single PDF.
+     *
+     * @param request  contains list of PDF URLs
+     */
+    @RequestMapping(value="/mergepdf", method = RequestMethod.POST, consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+        public void mergepdf(@RequestBody MergePdfRequest request, HttpServletResponse response) throws Exception {
+        response.setContentType("application/pdf");
+
+        WFRequest wf = new WFRequest();
+        com.fyhao.springwebapps.wf.step.MergeStep mstep = new com.fyhao.springwebapps.wf.step.MergeStep();
+        mstep.action = "merge";
+        mstep.urls = request.urls.toArray(new String[0]);
+        wf.steps.add(mstep);
+
+        WorkflowExecutor.generatePdf(wf, response);
+        }
     
 }

--- a/src/main/java/com/fyhao/springwebapps/dto/MergePdfRequest.java
+++ b/src/main/java/com/fyhao/springwebapps/dto/MergePdfRequest.java
@@ -1,0 +1,7 @@
+package com.fyhao.springwebapps.dto;
+
+import java.util.List;
+
+public class MergePdfRequest {
+    public List<String> urls;
+}

--- a/src/main/java/com/fyhao/springwebapps/wf/step/MergeStep.java
+++ b/src/main/java/com/fyhao/springwebapps/wf/step/MergeStep.java
@@ -1,0 +1,32 @@
+package com.fyhao.springwebapps.wf.step;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import com.fyhao.springwebapps.wf.WFContext;
+import com.fyhao.springwebapps.wf.WFStep;
+import com.itextpdf.kernel.pdf.PdfDocument;
+import com.itextpdf.kernel.pdf.PdfReader;
+import com.itextpdf.kernel.utils.PdfMerger;
+
+public class MergeStep extends WFStep {
+
+    public String[] urls;
+
+    @Override
+    public void execute(WFContext ctx) {
+        if (urls == null || ctx.pdfDocument == null) {
+            return;
+        }
+        PdfMerger merger = new PdfMerger(ctx.pdfDocument);
+        for (String u : urls) {
+            try (InputStream in = new URL(u).openStream();
+                 PdfDocument srcDoc = new PdfDocument(new PdfReader(in))) {
+                merger.merge(srcDoc, 1, srcDoc.getNumberOfPages());
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/test/java/MergeStepTests.java
+++ b/src/test/java/MergeStepTests.java
@@ -1,0 +1,56 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import com.fyhao.springwebapps.wf.WFContext;
+import com.fyhao.springwebapps.wf.step.MergeStep;
+import com.itextpdf.kernel.pdf.PdfDocument;
+import com.itextpdf.kernel.pdf.PdfReader;
+import com.itextpdf.kernel.pdf.PdfWriter;
+import com.itextpdf.layout.Document;
+import com.itextpdf.layout.element.AreaBreak;
+import com.itextpdf.layout.element.Paragraph;
+
+public class MergeStepTests {
+
+    private static void createPdf(Path path, int pages) throws Exception {
+        PdfWriter writer = new PdfWriter(path.toFile());
+        PdfDocument pdf = new PdfDocument(writer);
+        Document doc = new Document(pdf);
+        for (int i = 0; i < pages; i++) {
+            doc.add(new Paragraph("page" + (i + 1)));
+            if (i < pages - 1) {
+                doc.add(new AreaBreak());
+            }
+        }
+        doc.close();
+    }
+
+    @Test
+    public void mergeTwoPdfs() throws Exception {
+        Path p1 = Files.createTempFile("merge1", ".pdf");
+        Path p2 = Files.createTempFile("merge2", ".pdf");
+        createPdf(p1, 1);
+        createPdf(p2, 2);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PdfDocument dest = new PdfDocument(new PdfWriter(out));
+        WFContext ctx = new WFContext();
+        ctx.pdfDocument = dest;
+
+        MergeStep step = new MergeStep();
+        step.action = "merge";
+        step.urls = new String[] { p1.toUri().toString(), p2.toUri().toString() };
+        step.execute(ctx);
+        dest.close();
+
+        PdfDocument result = new PdfDocument(new PdfReader(new ByteArrayInputStream(out.toByteArray())));
+        assertEquals(3, result.getNumberOfPages());
+        result.close();
+    }
+}


### PR DESCRIPTION
## Summary
- add `MergeStep` for merging PDFs in workflow
- expose `/pdf/mergepdf` endpoint to trigger merge
- create `MergePdfRequest` DTO
- include unit test for merging PDFs
- document merge endpoint usage in README
- fix bootJar task configuration

## Testing
- `gradle test --no-daemon` *(fails: Could not resolve org.springframework.boot:spring-boot-gradle-plugin)*